### PR TITLE
v4.0 contains breaking changes

### DIFF
--- a/articles/aks/use-wasi-node-pools.md
+++ b/articles/aks/use-wasi-node-pools.md
@@ -169,7 +169,7 @@ spec:
       runtimeClassName: wasmtime-slight-v1
       containers:
         - name: hello-slight
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:latest
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:v0.3.3
           command: ["/"]
           resources:
             requests:


### PR DESCRIPTION
With the latest version of `slight`, it leads to the error: Error: failed to create containers task: failed to create shim task: could not load runtime spec: failed to load spec: io operation failed: invalid argument. This leads to pod being running but not ready.